### PR TITLE
Object additions and hook for appending Elements

### DIFF
--- a/src/JsonSchemaComponent.js
+++ b/src/JsonSchemaComponent.js
@@ -28,7 +28,9 @@ function JsonSchemaComponent(options) {
   var validation_errors_formatter = options.validation_errors_formatter || function(errors) {
     return errors;
   }
-  var json = $.parseJSON($(textarea).val());
+
+  var textareaValue = $(textarea).val() === '' ? '{}' : $(textarea).val();
+  var json = $.parseJSON(textareaValue);
 
   var validator;
   if (window.JSV != null) {
@@ -42,7 +44,8 @@ function JsonSchemaComponent(options) {
   if (options.existing_form == null) {
     var rendered = _this.render();
     var append_fn = rendered.appendPolyfillTo /* webshims support */ || rendered.appendTo;
-    append_fn.call(rendered, options.form);
+    var appendEl = options.appendEl ? options.appendEl : options.form;
+    append_fn.call(rendered, appendEl);
   }
 
   split_tags_by = RegExp(options.split_tags_by || /\ *,\ */);
@@ -245,4 +248,3 @@ return JsonSchemaComponent;
 
 
 }));
-

--- a/src/JsonSchemaComponent.specs.js
+++ b/src/JsonSchemaComponent.specs.js
@@ -67,6 +67,25 @@ describe("JsonSchemaComponent", function() {
       expect($("#testtextfield").val()).toEqual("value_a");
     });
 
+    it("should should pre-fill object in a simple form if textfield is empty", function() {
+      fixture.html('<textarea id=testtextarea></textarea>'+
+                   '<form id=testform><input type=text id="testtextfield" name=whale /></form>');
+
+      new JsonSchemaComponent({ 
+        schema:{
+          properties: {
+            whale: {
+              type: "string"
+            }
+          }
+        }, textarea:"#testtextarea", form:"#testform"});
+
+      $('#testtextfield').val("moby");
+      $('#testtextfield').trigger("change");
+      
+      expect(json_val($("#testtextarea")).whale).toEqual('moby');
+    });
+
     it("should should fill boolean values in a provided form with two checkboxes", function() {
       fixture.html('<textarea id=testtextarea>{"field_a": true, "field_b": false}</textarea>'+
                    '<form id=testform>'+
@@ -400,6 +419,31 @@ describe("JsonSchemaComponent", function() {
         '<textarea id=testtextarea>{}</textarea>'+
         '<form id=testform></form>'
       );
+    });
+
+    it("should should append the fields below a given Element", function() {
+
+      fixture.html(
+        '<textarea id=testtextarea>{"whale": "Moby Dick"}</textarea>'+
+        '<form id=testform>' +
+        '<div id=hook></div>' +
+        '</form>'
+      );
+
+      new JsonSchemaComponent({
+        textarea:"#testtextarea",
+        form:"#testform",
+        schema: {
+          properties: {
+            whale: {
+              type: "string"
+            }
+          }
+        },
+        appendEl: "#hook"
+      });
+
+      expect($("#hook").html()).toContain('<label>');
     });
 
     it("should should render a simple one-textfield-form", function() {


### PR DESCRIPTION
If no initial object is provided in the textarea, js will raise an error complaining it cannot parse null values. This will fix this issue, creating an initial 'object' JSON can parse.

Additional a hook was provided where the fields will be added to as the initial state would cause the fields to appear below submit buttons etc. 
- option to place fields at selector hook
- ability to create object from scratch if no value is given
- specs
